### PR TITLE
kill previous instances of golden

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ bspc rule -a retroarch state=floating
 bspc rule -a plasmashell state=floating border=off layer=normal manage=off center=true
 bspc rule -a krunner state=floating
 
-exec ~/Projects/golden/run.sh &
+pkill golden.sh &
+~/Projects/golden/golden.sh &
 ```
 
 Bugs, issues and questions all welcome in the Issues section. Thank you!

--- a/golden.sh
+++ b/golden.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# grabbed this badboy from https://stackoverflow.com/a/246128/149987
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+# kill any exististing golden.py processes
+ps xu | grep golden.py | grep -v grep | awk '{ print $2 }' | xargs kill -9 &
+
+while true
+do
+    bspc subscribe node_focus | $DIR/golden.py
+done


### PR DESCRIPTION
Rename run.sh to golden.sh for easier grepping of the process.

When restarting bspwm only `golden.py` process will be active. I don't know why, but this does not seem to interfere with the behavior, and no duplicate processes were spawned in my testing.